### PR TITLE
Update dependencies and fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,22 +36,22 @@
     "Windows"
   ],
   "dependencies": {
-    "q": "^1.4.1",
-    "cordova": "6.1.1",
-    "pwabuilder-lib": "^2.0.0-rc"
+    "cordova": "^8.1.2",
+    "pwabuilder-lib": "^2.0.0-rc",
+    "q": "^1.4.1"
   },
   "devDependencies": {
     "blanket": "1.1.6",
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-jshint": "^0.11.3",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt": "^1.0.3",
+    "grunt-cli": "^1.3.2",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-nodeunit": "^2.0.0",
+    "grunt-contrib-watch": "^1.1.0",
     "grunt-mocha-test": "^0.12.7",
     "jshint-stylish": "^1.0.0",
     "jshint-teamcity": "^1.0.6",
-    "load-grunt-tasks": "^1.0.0",
-    "mocha": "^2.1.0",
+    "load-grunt-tasks": "^4.0.0",
+    "mocha": "^5.2.0",
     "mocha-teamcity-reporter": "0.0.4",
     "should": "^5.0.1",
     "time-grunt": "^1.0.0",


### PR DESCRIPTION
Update the package dependencies and fix most of the vulnerabilities from them. The vulnerabilities went down from 118 to a single low-level one that's up to cordova to update.